### PR TITLE
Add ability to configure GitLab URL through environment to use with self-hosted GitLab CE

### DIFF
--- a/services/gitlab/gitlab.go
+++ b/services/gitlab/gitlab.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -58,6 +59,12 @@ const apiSuffixURL = "/api/v3/"
 
 // Service returns integram.Service from gitlab.Config
 func (c Config) Service() *integram.Service {
+	uri := os.Getenv("INTEGRAM_GITLAB_BASE_URL")
+
+	if uri == "" {
+		uri = "https://gitlab.com"
+	}
+
 	return &integram.Service{
 		Name:                "gitlab",
 		NameToPrint:         "GitLab",
@@ -88,8 +95,8 @@ func (c Config) Service() *integram.Service {
 				ClientID:     c.ID,
 				ClientSecret: c.Secret,
 				Endpoint: oauth2.Endpoint{
-					AuthURL:  "https://gitlab.com/oauth/authorize",
-					TokenURL: "https://gitlab.com/oauth/token",
+					AuthURL:  fmt.Sprintf("%s/oauth/authorize", uri),
+					TokenURL: fmt.Sprintf("%s/oauth/token", uri),
 				},
 			},
 		},


### PR DESCRIPTION
environment variable `INTEGRAM_GITLAB_BASE_URL `
`INTEGRAM_GITLAB_BASE_URL=https://gitlab.com` 

For self-hosted GitLab CE

## Example

```
.
├── docker-compose.yml
├── Dockerfile
├── integram.crt
├── integram.key
├── main.go
└── public.crt
```

### Dockerfile

```Dockerfile
FROM golang:alpine

RUN apk --no-cache add git ca-certificates openssl

ENV INTEGRAM_PORT 443
ENV INTEGRAM_BASE_URL https://example.org:8093
ENV INTEGRAM_GITLAB_BASE_URL https://example.org

WORKDIR /go/src/app
EXPOSE 443
# using my fork until pull request is merged
RUN go-wrapper download  github.com/requilence/integram; \
    cd /go/src/github.com/requilence/integram; \
    git remote add hrsrashid https://github.com/hrsrashid/integram.git; \
    git pull --rebase hrsrashid master; \
    cd /go/src/app

# cat command is work-around
COPY public.crt /usr/local/share/ca-certificates/code/ 
RUN update-ca-certificates; \
    cat /usr/local/share/ca-certificates/code/public.crt >> /etc/ssl/certs/ca-certificates.crt

COPY . ./
CMD ["go", "run", "main.go"]
```

### docker-compose.yml

```yml
version: '2'
services:
    mongo:
        image: mongo
        restart: always
        volumes:
            - data:/data/db
    redis:
        image: redis:alpine
        restart: always
    bot:
        build: .
        restart: always
        environment:
            INTEGRAM_MONGO_URL: mongo
            INTEGRAM_REDIS_URL: redis:6379
        ports:
            - 8093:443

volumes:
    data: {}
```

